### PR TITLE
celeryのバージョンを固定

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -50,7 +50,7 @@ RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-
 
 RUN pip install pip==9.0.3
 RUN pip install Cython pytz pyOpenSSL ndg-httpsclient pyasn1 flask_bcrypt
-RUN pip install pandas-gbq==0.2.0 pandas==0.20.3 werkzeug==0.14
+RUN pip install pandas-gbq==0.2.0 pandas==0.20.3 werkzeug==0.14 celery==4.4.7
 RUN pip install apache-airflow[crypto,celery,postgres,gcp_api]==$AIRFLOW_VERSION
 #RUN pip install "git+https://github.com/apache/incubator-airflow.git@${AIRFLOW_VERSION}#egg=apache-airflow[crypto,celery,postgres,gcp_api]"
 RUN pip install google-cloud-bigquery==0.27.0 slackweb


### PR DESCRIPTION
celeryの5.0.0以降だとバックエンドにAMQPが使えなくなった